### PR TITLE
docs: OpenClaw runbook entries + GitHub Pages deploy fix

### DIFF
--- a/.vitepress/sidebar.ts
+++ b/.vitepress/sidebar.ts
@@ -196,6 +196,38 @@ export function sidebar() {
             text: "OPENCLAW-001: Gateway and Config",
             link: "/runbook/issues/openclaw/OPENCLAW-001",
           },
+          {
+            text: "OPENCLAW-002: Token Auth / WebSocket 1008",
+            link: "/runbook/issues/openclaw/OPENCLAW-002",
+          },
+          {
+            text: "OPENCLAW-003: Context Overflow / 402 / TPM",
+            link: "/runbook/issues/openclaw/OPENCLAW-003",
+          },
+          {
+            text: "OPENCLAW-004: Telegram Not Replying",
+            link: "/runbook/issues/openclaw/OPENCLAW-004",
+          },
+          {
+            text: "OPENCLAW-005: Config EBUSY / exec-approvals",
+            link: "/runbook/issues/openclaw/OPENCLAW-005",
+          },
+          {
+            text: "OPENCLAW-006: Tool Schema (boolean vs string)",
+            link: "/runbook/issues/openclaw/OPENCLAW-006",
+          },
+          {
+            text: "OPENCLAW-007: Gmail via Elder",
+            link: "/runbook/issues/openclaw/OPENCLAW-007",
+          },
+          {
+            text: "OPENCLAW-008: Deployment Delete / Helm Drift",
+            link: "/runbook/issues/openclaw/OPENCLAW-008",
+          },
+          {
+            text: "OPENCLAW-009: OOM / Heap",
+            link: "/runbook/issues/openclaw/OPENCLAW-009",
+          },
         ],
       },
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ After **1.0.0** release:
 
 ### Added
 
+- **OpenClaw runbook (OPENCLAW-002–009)** — Documented Eldertree production issues: token vs trusted-proxy WebSocket 1008, context overflow / OpenRouter 402 / Groq TPM, Telegram 409 and egress, config EBUSY / PVC seeding, Groq tool schema errors, Gmail via Elder, accidental Deployment delete / Helm drift, OOM/heap. Updated OPENCLAW-001 for current token-auth standard.
 - Initial VitePress documentation site structure
 - Runbook system with searchable issue files
 - Migration of troubleshooting docs from pi-fleet

--- a/runbook/index.md
+++ b/runbook/index.md
@@ -33,8 +33,14 @@ This runbook contains documented solutions for known issues in the eldertree Kub
 | GitHub workflow fails                | [CICD-001](/runbook/issues/cicd/CICD-001)                                              |
 | Reusable workflow not found          | [CICD-001](/runbook/issues/cicd/CICD-001)                                              |
 | Docker build fails in CI             | [CICD-001](/runbook/issues/cicd/CICD-001)                                              |
-| OpenClaw Web UI 1008 / token        | [OPENCLAW-001](/runbook/issues/openclaw/OPENCLAW-001)                                 |
-| OpenClaw config / doctor / EROFS     | [OPENCLAW-001](/runbook/issues/openclaw/OPENCLAW-001)                                 |
+| OpenClaw Web UI 1008 / token        | [OPENCLAW-001](/runbook/issues/openclaw/OPENCLAW-001), [OPENCLAW-002](/runbook/issues/openclaw/OPENCLAW-002) |
+| OpenClaw config / doctor / EROFS     | [OPENCLAW-001](/runbook/issues/openclaw/OPENCLAW-001), [OPENCLAW-005](/runbook/issues/openclaw/OPENCLAW-005) |
+| OpenClaw context overflow / 402      | [OPENCLAW-003](/runbook/issues/openclaw/OPENCLAW-003)                                 |
+| Telegram bot not replying            | [OPENCLAW-004](/runbook/issues/openclaw/OPENCLAW-004)                                 |
+| OpenClaw tool call validation failed   | [OPENCLAW-006](/runbook/issues/openclaw/OPENCLAW-006)                                 |
+| Elder read my emails / Gmail         | [OPENCLAW-007](/runbook/issues/openclaw/OPENCLAW-007)                                 |
+| OpenClaw deployment missing          | [OPENCLAW-008](/runbook/issues/openclaw/OPENCLAW-008)                                 |
+| OpenClaw OOM / heap limit            | [OPENCLAW-009](/runbook/issues/openclaw/OPENCLAW-009)                                 |
 
 ### By Category
 
@@ -95,6 +101,14 @@ This runbook contains documented solutions for known issues in the eldertree Kub
 #### OpenClaw Issues
 
 - [OPENCLAW-001: Gateway and Config Issues](/runbook/issues/openclaw/OPENCLAW-001)
+- [OPENCLAW-002: Gateway Auth — Token vs Trusted-Proxy](/runbook/issues/openclaw/OPENCLAW-002)
+- [OPENCLAW-003: LLM Context Overflow and Provider Limits](/runbook/issues/openclaw/OPENCLAW-003)
+- [OPENCLAW-004: Telegram Bot Not Replying](/runbook/issues/openclaw/OPENCLAW-004)
+- [OPENCLAW-005: Config EBUSY / PVC and exec-approvals](/runbook/issues/openclaw/OPENCLAW-005)
+- [OPENCLAW-006: Tool Call Schema Failures](/runbook/issues/openclaw/OPENCLAW-006)
+- [OPENCLAW-007: Gmail Read/Write via Elder](/runbook/issues/openclaw/OPENCLAW-007)
+- [OPENCLAW-008: Accidental Deployment Delete / Helm Drift](/runbook/issues/openclaw/OPENCLAW-008)
+- [OPENCLAW-009: OpenClaw OOM and Node Memory](/runbook/issues/openclaw/OPENCLAW-009)
 
 #### Physical hardware
 

--- a/runbook/issues/openclaw/OPENCLAW-001.md
+++ b/runbook/issues/openclaw/OPENCLAW-001.md
@@ -38,7 +38,18 @@ symptoms:
 
 ## Resolution
 
-### 1. Trusted-proxy auth (fix 1008)
+> **Current standard (2026-04+):** Use **token auth**, not trusted-proxy. See [OPENCLAW-002](/runbook/issues/openclaw/OPENCLAW-002) for WebSocket 1008 / `trusted_proxy_untrusted_source`. The trusted-proxy steps below are **legacy**.
+
+### 1. Token auth (fix 1008 for internal clients + Web UI)
+
+In OpenClaw config (`openclaw-config-file` ConfigMap):
+
+- Set `gateway.auth.mode` to `"token"`.
+- Set `gateway.auth.token` to `"${OPENCLAW_GATEWAY_TOKEN}"`.
+- Remove Traefik `add-trusted-proxy-user` middleware from OpenClaw ingress.
+- Web UI: paste token from Vault `secret/openclaw/gateway` once.
+
+### 1b. Trusted-proxy auth (legacy — do not use on Eldertree)
 
 In OpenClaw config (`openclaw-config-file` ConfigMap):
 
@@ -46,7 +57,7 @@ In OpenClaw config (`openclaw-config-file` ConfigMap):
 - Configure `gateway.auth.trustedProxy` with `userHeader: "x-forwarded-user"` and `allowUsers: ["local"]`.
 - In Traefik IngressMiddleware, add header `X-Forwarded-User: local` for the OpenClaw route.
 
-### 2. Config schema (2026)
+**Note:** Loopback gateway clients still fail with trusted-proxy; use token auth instead.
 
 - Remove any top-level `providers` or `models.default`.
 - Use `agents.defaults.model.primary` and `agents.defaults.model.fallbacks` with `provider/model` ids.
@@ -84,10 +95,16 @@ In config, under `gateway.controlUi`:
 
 ## Verification
 
-- Web UI loads at https://openclaw.eldertree.local without entering a token.
+- Web UI loads at https://openclaw.eldertree.local (paste gateway token when prompted).
 - Pod is 1/1 Running; no restart loop.
 - Logs show gateway listening and no EROFS or config write errors.
 - Health: `curl -s https://openclaw.eldertree.local/health` returns 200.
+
+## See Also
+
+- [OPENCLAW-002](/runbook/issues/openclaw/OPENCLAW-002) — token auth vs trusted-proxy
+- [OPENCLAW-005](/runbook/issues/openclaw/OPENCLAW-005) — EBUSY / PVC config seeding
+- [OPENCLAW-009](/runbook/issues/openclaw/OPENCLAW-009) — OOM / heap
 
 ## All models failed (Google / Groq / Ollama)
 
@@ -96,6 +113,16 @@ If logs show **FailoverError** or **All models failed** for `google`, `groq`, or
 1. **Google:** "No API key found for provider google" — Ensure `GOOGLE_API_KEY` is in `openclaw-secrets` and the config has `models.providers.google.apiKey: "${GOOGLE_API_KEY}"` so the gateway uses the env var.
 2. **Groq:** "Unknown model: groq/llama-3.1-70b-versatile" — Use the current catalog id (e.g. `groq/llama-3.3-70b-versatile`). Ensure `GROQ_API_KEY` is set when using Groq.
 3. **Ollama:** "Unknown model: ollama/... Ollama requires authentication" — Set `OLLAMA_API_KEY` (e.g. to `ollama-local`) so the provider is registered; the entrypoint can default it with `export OLLAMA_API_KEY="${OLLAMA_API_KEY:-ollama-local}"`.
+
+## In-container `openclaw update` (not supported)
+
+Logs may show `update available (latest): v2026.x.x`. **`openclaw update` inside the Kubernetes pod is not supported** — the image is read-only GitOps-managed. Upgrade path:
+
+1. GitHub Action builds `ghcr.io/raolivei/openclaw` (ARM64).
+2. Flux reconciles `pi-fleet` HelmRelease / image tag.
+3. Or Elder `elder_upgrade` with approval (if configured).
+
+Do not grant shell "permissions" for in-pod self-update; fix is a new image rollout.
 
 ## Related Files
 

--- a/runbook/issues/openclaw/OPENCLAW-002.md
+++ b/runbook/issues/openclaw/OPENCLAW-002.md
@@ -1,0 +1,67 @@
+---
+id: OPENCLAW-002
+title: Gateway Auth — Token vs Trusted-Proxy (WebSocket 1008)
+category: openclaw
+severity: high
+symptoms:
+  - WebSocket closed with code 1008 unauthorized
+  - trusted_proxy_untrusted_source in logs
+  - sessions_list failed; internal tools cannot reach gateway
+  - Web UI works but Telegram tools fail
+---
+
+# OPENCLAW-002: Gateway Auth — Token vs Trusted-Proxy (WebSocket 1008)
+
+## Symptoms
+
+- Logs show `[ws] unauthorized` with `reason=trusted_proxy_untrusted_source`.
+- `[tools] sessions_list failed: gateway closed (1008): unauthorized`.
+- In-pod clients connect to `ws://127.0.0.1:18789` without `X-Forwarded-User`.
+- Traefik Web UI may work while **internal** gateway clients (Telegram agent, tools) fail.
+
+## Error Messages (Searchable)
+
+- `trusted_proxy_untrusted_source`
+- `gateway closed (1008): unauthorized`
+- `sessions_list failed`
+- `GatewayClientRequestError: unauthorized`
+- `ws://127.0.0.1:18789`
+
+## Root Cause
+
+**Trusted-proxy** auth expects the configured identity header (`X-Forwarded-User`) on **every** connection. Loopback clients inside the OpenClaw pod do not send that header, so they are rejected even when `trustedProxies` includes `127.0.0.0/8`. See [openclaw#43300](https://github.com/openclaw/openclaw/issues/43300).
+
+Adding loopback CIDRs to `trustedProxies` does **not** fix missing headers.
+
+## Resolution (current Eldertree standard)
+
+Use **`gateway.auth.mode: "token"`** with `token: "${OPENCLAW_GATEWAY_TOKEN}"` in `openclaw-config-file` ConfigMap. Remove Traefik `add-trusted-proxy-user` middleware from the OpenClaw ingress.
+
+1. **Config** (`pi-fleet/clusters/eldertree/openclaw/configmap.yaml`):
+
+   ```json
+   "auth": {
+     "mode": "token",
+     "token": "${OPENCLAW_GATEWAY_TOKEN}"
+   }
+   ```
+
+2. **Secret** — Vault `secret/openclaw/gateway` → k8s `openclaw-secrets` key `OPENCLAW_GATEWAY_TOKEN`.
+
+3. **Web UI** — Open https://openclaw.eldertree.local and paste the gateway token once when prompted.
+
+4. **Restart** — `kubectl rollout restart deployment/openclaw -n openclaw`.
+
+## Verification
+
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+kubectl logs -n openclaw deployment/openclaw --since=1h | grep -iE 'trusted_proxy|1008|unauthorized' || echo "no auth errors"
+```
+
+No `trusted_proxy_untrusted_source` lines after restart. Telegram tools that call the gateway should succeed.
+
+## Related
+
+- [OPENCLAW-001](/runbook/issues/openclaw/OPENCLAW-001) — general gateway/config (legacy trusted-proxy notes)
+- `pi-fleet/clusters/eldertree/openclaw/README.md`

--- a/runbook/issues/openclaw/OPENCLAW-003.md
+++ b/runbook/issues/openclaw/OPENCLAW-003.md
@@ -1,0 +1,92 @@
+---
+id: OPENCLAW-003
+title: LLM Context Overflow and Provider Limits (402 / TPM)
+category: openclaw
+severity: high
+symptoms:
+  - Context overflow prompt too large for the model
+  - OpenRouter 402 insufficient credits or max_tokens
+  - Groq 413 Request too large TPM Limit 12000
+  - Auto-compaction failed
+  - Elder stops replying after long Telegram threads
+---
+
+# OPENCLAW-003: LLM Context Overflow and Provider Limits (402 / TPM)
+
+## Symptoms
+
+- Telegram: **"Context overflow: prompt too large for the model"** — try `/reset` or `/new`.
+- **"Auto-compaction could not recover this turn"** after overflow.
+- Logs: `402 Prompt tokens limit exceeded` or `402 Insufficient credits`.
+- Groq: `413 Request too large ... TPM: Limit 12000, Requested 45005`.
+- Failover loops across models without a successful reply.
+
+## Error Messages (Searchable)
+
+- `Context overflow: prompt too large`
+- `402 Prompt tokens limit exceeded`
+- `402 Insufficient credits`
+- `auto-compaction failed`
+- `reserveTokensFloor`
+- `TPM: Limit 12000`
+- `FailoverError: API rate limit reached`
+
+## Root Causes
+
+| Cause | What happens |
+|-------|----------------|
+| **Huge session on PVC** | 297+ messages; prompt exceeds provider cap even after `/new` confusion |
+| **OpenRouter billing** | Free/low balance; large `max_tokens` or prompt over route limit (~25k for some models) |
+| **Groq free tier TPM** | `llama-3.3-70b-versatile` on-demand tier ~12k TPM; 45k-token session fails every request |
+| **`contextTokens` too low vs `reserveTokensFloor`** | e.g. 22k context + 20k floor → only ~2k usable; overflow on first message |
+| **Pasting large logs in Telegram** | Inflates session immediately |
+
+## Resolution
+
+### 1. Start fresh
+
+In Telegram: **`/new`** or **`/reset`**. If the session file on PVC is huge, archive it (see pi-fleet openclaw ops) and restart the pod.
+
+### 2. Tune `agents.defaults` in ConfigMap
+
+Recommended starting points (adjust per primary model):
+
+```json
+"contextTokens": 80000,
+"compaction": {
+  "mode": "safeguard",
+  "reserveTokensFloor": 20000,
+  "model": "<same provider as primary or cheaper Groq model>",
+  "memoryFlush": { "enabled": false }
+}
+```
+
+- **`reserveTokensFloor: 20000`** — Elder/OpenClaw suggests this when compaction cannot run.
+- Do **not** set `contextTokens` below ~32k if `reserveTokensFloor` is 20k.
+
+### 3. Pick a viable primary model
+
+| Model | Notes |
+|-------|--------|
+| `groq/openai/gpt-oss-120b` | Higher TPM (250k); good tool calling |
+| `groq/llama-3.3-70b-versatile` | Strong but **12k TPM** on free on-demand tier — bad for large sessions |
+| `groq/meta-llama/llama-4-scout-17b-16e-instruct` | Higher TPM; weaker tool-call JSON (see OPENCLAW-006) |
+| OpenRouter routes | Require credits at [openrouter.ai/settings/credits](https://openrouter.ai/settings/credits) |
+
+Catalog `contextWindow` for OpenRouter Gemini should reflect **real** route limits (~24k), not 1M marketing numbers.
+
+### 4. Keep email / kubectl output small
+
+When reading mail or logs via tools, cap results (e.g. **5–10** messages, snippets only). See [OPENCLAW-007](/runbook/issues/openclaw/OPENCLAW-007).
+
+## Verification
+
+```bash
+kubectl logs -n openclaw deployment/openclaw --tail=50 | grep -iE 'overflow|402|TPM|compaction'
+```
+
+Send a **short** test message in Telegram after `/new`; gateway should log a successful agent run.
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/configmap.yaml`

--- a/runbook/issues/openclaw/OPENCLAW-004.md
+++ b/runbook/issues/openclaw/OPENCLAW-004.md
@@ -1,0 +1,75 @@
+---
+id: OPENCLAW-004
+title: Telegram Bot Not Replying (409 / Network)
+category: openclaw
+severity: high
+symptoms:
+  - Elder bot silent on Telegram
+  - 409 Conflict getUpdates
+  - fetch fallback IPv4-only ETIMEDOUT ENETUNREACH
+  - Only one bot instance should be running
+---
+
+# OPENCLAW-004: Telegram Bot Not Replying (409 / Network)
+
+## Symptoms
+
+- `@eldertree_assistant_bot` does not respond; pod is **Running**.
+- Logs: `[telegram] fetch fallback: enabling sticky IPv4-only dispatcher (codes=ETIMEDOUT,ENETUNREACH)` or `UND_ERR_SOCKET`.
+- **`409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running`**.
+
+## Error Messages (Searchable)
+
+- `409: Conflict`
+- `terminated by other getUpdates request`
+- `fetch fallback: enabling sticky IPv4-only dispatcher`
+- `ETIMEDOUT`
+- `ENETUNREACH`
+- `UND_ERR_SOCKET`
+- `getUpdates conflict`
+
+## Diagnosis
+
+### A. Duplicate long-poll (409)
+
+Telegram allows **one** `getUpdates` client per bot token. Another process holds the poll:
+
+- Second OpenClaw pod or old replica (rare with `Recreate` strategy).
+- **Local OpenClaw** / dev container using the same Vault token.
+- Another cluster or laptop session.
+
+```bash
+# From OpenClaw pod — should succeed when no duplicate
+kubectl exec -n openclaw deploy/openclaw -- sh -c \
+  'wget -qO- "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo"'
+# url must be empty; pending_update_count is informational
+```
+
+### B. Egress / DNS (ETIMEDOUT)
+
+Cluster egress to `api.telegram.org` flaky (IPv6 path, DNS, or uplink). OpenClaw enables IPv4-only fallback automatically; persistent failures need network investigation ([NET-001](/runbook/issues/network/NET-001)).
+
+## Resolution
+
+### 409 — stop duplicate poller
+
+1. Find and stop any **local** OpenClaw/gateway using the same bot token.
+2. Restart cluster bot only: `kubectl rollout restart deployment/openclaw -n openclaw`.
+3. If unresolved, **rotate token** in @BotFather → update Vault `secret/openclaw/telegram` → restart OpenClaw.
+
+### Network
+
+1. From pod: `wget -qO- --timeout=20 https://api.telegram.org` and `getMe` with token.
+2. Check node egress / Pi-hole / firewall if timeouts persist.
+
+## Verification
+
+```bash
+kubectl logs -n openclaw deployment/openclaw --since=10m | grep -i telegram
+```
+
+Expect `[telegram] [default] starting provider` without repeating 409 errors. Send a test DM.
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/externalsecret.yaml` (`TELEGRAM_BOT_TOKEN`)

--- a/runbook/issues/openclaw/OPENCLAW-005.md
+++ b/runbook/issues/openclaw/OPENCLAW-005.md
@@ -1,0 +1,65 @@
+---
+id: OPENCLAW-005
+title: Config File EBUSY / PVC and exec-approvals EROFS
+category: openclaw
+severity: medium
+symptoms:
+  - EBUSY resource busy or locked openclaw.json
+  - EROFS read-only exec-approvals.json
+  - missing-meta-before-write config anomaly
+  - Stale model on PVC vs ConfigMap
+  - allowlist miss for kubectl exec
+---
+
+# OPENCLAW-005: Config File EBUSY / PVC and exec-approvals EROFS
+
+## Symptoms
+
+- `failed to persist plugin auto-enable changes: Error: EBUSY ... rename ... openclaw.json`.
+- `Config observe anomaly: missing-meta-vs-last-good` / `missing-meta-before-write`.
+- Gateway logs show wrong **agent model** (e.g. old `gpt-4o-mini`) while Git ConfigMap has `gpt-oss-120b`.
+- `exec-approvals.json` EROFS when OpenClaw tries to mutate allowlist.
+- `allowlist miss` for elevated `kubectl` commands.
+
+## Error Messages (Searchable)
+
+- `EBUSY: resource busy or locked`
+- `openclaw.json`
+- `EROFS: read-only file system`
+- `exec-approvals.json`
+- `missing-meta-before-write`
+- `Config overwrite`
+- `allowlist miss`
+
+## Root Cause
+
+1. **`openclaw.json` as ConfigMap subPath** — File is bind-mounted read-only; atomic rename for plugin persistence fails with **EBUSY**.
+2. **Stale PVC copy** — Writable config on PVC from experiments overrides GitOps intent.
+3. **`exec-approvals.json` on ConfigMap mount** — OpenClaw must **write** this file; direct mount → **EROFS**.
+
+## Resolution (Eldertree standard)
+
+Startup script in `helmrelease.yaml`:
+
+1. Mount ConfigMap at **`/etc/openclaw-config`** (not as subPath on `openclaw.json`).
+2. **Copy** `config.json` → `$OPENCLAW_DIR/openclaw.json` on PVC **only when ConfigMap SHA-256 changes** (or file missing). Preserves OpenClaw file metadata across restarts.
+3. **Copy** `exec-approvals.json` from `/etc/openclaw-defaults/` to PVC on every start.
+
+Skip `openclaw doctor` when config is seeded from ConfigMap.
+
+## Verification
+
+```bash
+kubectl logs -n openclaw deployment/openclaw --tail=30 | grep -E 'Seeded|EBUSY|EROFS'
+```
+
+Expect:
+
+- `[openclaw] Seeded openclaw.json from ConfigMap` or `Keeping PVC openclaw.json (ConfigMap hash unchanged)`
+- `[openclaw] Seeded exec-approvals.json`
+- No EBUSY on startup
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/helmrelease.yaml`
+- `pi-fleet/clusters/eldertree/openclaw/exec-approvals-configmap.yaml`

--- a/runbook/issues/openclaw/OPENCLAW-006.md
+++ b/runbook/issues/openclaw/OPENCLAW-006.md
@@ -1,0 +1,52 @@
+---
+id: OPENCLAW-006
+title: Tool Call Schema Failures (Groq Llama Scout)
+category: openclaw
+severity: medium
+symptoms:
+  - tool call validation failed exec parameters did not match schema
+  - pty background elevated expected boolean but got string
+  - kubectl or curl commands never run from Telegram
+---
+
+# OPENCLAW-006: Tool Call Schema Failures (Groq Llama Scout)
+
+## Symptoms
+
+Telegram shows:
+
+```text
+tool call validation failed: parameters for tool exec did not match schema:
+errors: [/pty: expected boolean, but got string, /background: expected boolean, but got string,
+/elevated: expected boolean, but got string]
+```
+
+User asked for kubectl logs or similar; agent never executes.
+
+## Error Messages (Searchable)
+
+- `tool call validation failed`
+- `expected boolean, but got string`
+- `/pty: expected boolean`
+- `/elevated: expected boolean`
+
+## Root Cause
+
+Smaller models (e.g. **`groq/meta-llama/llama-4-scout-17b-16e-instruct`**) emit tool arguments as **strings** (`"true"`) instead of JSON **booleans** (`true`). OpenClaw's `exec` tool schema rejects them.
+
+## Resolution
+
+Switch primary to a model with reliable function calling:
+
+- **`groq/openai/gpt-oss-120b`** (recommended on Eldertree — higher TPM, GPT-style tools)
+- **`groq/llama-3.3-70b-versatile`** (better than Scout; watch TPM limits — [OPENCLAW-003](/runbook/issues/openclaw/OPENCLAW-003))
+
+Update `agents.defaults.model.primary` in `configmap.yaml`, Flux reconcile, restart OpenClaw.
+
+## Verification
+
+Ask Telegram: *"Show me pods in namespace swimto"* — should run `kubectl` without schema error.
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/configmap.yaml`

--- a/runbook/issues/openclaw/OPENCLAW-007.md
+++ b/runbook/issues/openclaw/OPENCLAW-007.md
@@ -1,0 +1,84 @@
+---
+id: OPENCLAW-007
+title: Gmail Read/Write via Elder
+category: openclaw
+severity: medium
+symptoms:
+  - read my unread emails fails or context overflow
+  - Elder cannot access Gmail
+  - 401 from Elder API
+  - Gmail refresh token not configured
+---
+
+# OPENCLAW-007: Gmail Read/Write via Elder
+
+## Architecture
+
+OpenClaw does **not** call Gmail directly. Flow:
+
+```text
+Telegram → OpenClaw (curl + ELDER_API_KEY) → Elder /api/gmail/* → Gmail API (OAuth)
+```
+
+## Symptoms
+
+- "Read my unread emails" → context overflow (too many tokens) or no action.
+- `401 Missing API key` from Elder.
+- `500 Gmail refresh token not configured` / `Failed to refresh Gmail credentials`.
+- Connection refused OpenClaw → Elder.
+
+## Error Messages (Searchable)
+
+- `Gmail refresh token not configured`
+- `Failed to refresh Gmail credentials`
+- `Missing API key. Provide X-API-Key header`
+- `Connection refused` to `elder.openclaw.svc.cluster.local`
+
+## Setup Checklist
+
+### 1. Vault — `secret/openclaw/gmail`
+
+Keys: `client-id`, `client-secret`, `refresh-token`, `user-email`.
+
+```bash
+cd pi-fleet
+./scripts/setup-openclaw-gmail.sh
+```
+
+Full guide: `pi-fleet/clusters/eldertree/openclaw/GMAIL_SETUP.md`
+
+Google Cloud: enable **Gmail API**, OAuth desktop client, scopes `gmail.readonly`, `gmail.send`, `gmail.modify` (or `https://mail.google.com/`).
+
+### 2. Kubernetes
+
+- ExternalSecret maps Gmail keys → `openclaw-secrets` → **Elder** env `ELDER_GMAIL_*`.
+- OpenClaw needs **`ELDER_API_KEY`** (from `elder-secrets`) and **`ELDER_URL`**.
+- NetworkPolicy must allow `app: openclaw-openclaw`, `component: openclaw` → Elder port 8000.
+
+### 3. Skills
+
+`gmail-skill.md` in `openclaw-skills` ConfigMap documents `curl` examples with `X-API-Key`.
+
+## Usage Tips (avoid context overflow)
+
+- List with **`max_results: 5–10`**; summarize **snippets** only.
+- Use `/new` before large mail tasks.
+- Confirm recipient/subject/body before **send**.
+
+## Verification
+
+```bash
+ELDER_KEY=$(kubectl get secret elder-secrets -n openclaw -o jsonpath='{.data.API_KEY}' | base64 -d)
+
+kubectl exec -n openclaw deploy/openclaw -- sh -c \
+  "curl -sS -X POST \"\${ELDER_URL}/api/gmail/list\" \
+    -H \"X-API-Key: \${ELDER_API_KEY}\" \
+    -H \"Content-Type: application/json\" \
+    -d '{\"query\":\"is:unread\",\"max_results\":3}'"
+```
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/GMAIL_SETUP.md`
+- `pi-fleet/clusters/eldertree/openclaw/skills-configmap.yaml`
+- `elder/backend/api/routes/gmail.py`

--- a/runbook/issues/openclaw/OPENCLAW-008.md
+++ b/runbook/issues/openclaw/OPENCLAW-008.md
@@ -1,0 +1,73 @@
+---
+id: OPENCLAW-008
+title: Accidental Deployment Delete / Helm Drift
+category: openclaw
+severity: high
+symptoms:
+  - No pods in openclaw namespace but HelmRelease Ready
+  - kubectl get deploy -n openclaw empty
+  - Services and ingress remain
+  - Elder and OpenClaw missing after mistaken delete
+---
+
+# OPENCLAW-008: Accidental Deployment Delete / Helm Drift
+
+## Symptoms
+
+- `kubectl get deploy,pods -n openclaw` → **No resources found**.
+- `kubectl get helmrelease openclaw -n openclaw` still shows **Ready** / `UpgradeSucceeded`.
+- `helm status openclaw-openclaw -n openclaw` lists Services/Ingress but **no Deployments**.
+- Telegram bot and Web UI down.
+
+## Root Cause
+
+Deployments were **`kubectl delete deployment ...`** outside Helm. Helm release state still thinks revision N is deployed; **Flux reconcile alone may not recreate** missing Deployments.
+
+## Resolution
+
+### Option A — Force Helm upgrade (fastest)
+
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+cd /path/to/pi-fleet
+KUBECONFIG=~/.kube/config-eldertree helm upgrade openclaw-openclaw ./helm/eldertree-app \
+  -n openclaw --reuse-values
+```
+
+Wait for rollouts:
+
+```bash
+kubectl rollout status deployment/openclaw -n openclaw
+kubectl rollout status deployment/elder -n openclaw
+```
+
+### Option B — Flux
+
+```bash
+flux reconcile helmrelease openclaw -n openclaw
+```
+
+If Deployments still missing, use Option A.
+
+### Option C — Delete HelmRelease and re-apply (last resort)
+
+Only if release is corrupted; may cause brief ingress disruption. Prefer A.
+
+## Verification
+
+```bash
+kubectl get deploy,pods -n openclaw
+kubectl logs -n openclaw deployment/openclaw --tail=20
+```
+
+Both `openclaw` and `elder` Deployments should be **1/1 Ready**.
+
+## Prevention
+
+- Prefer **`kubectl rollout restart deployment/openclaw -n openclaw`** over delete.
+- Use GitOps (pi-fleet) as source of truth; avoid manual edits to Deployments.
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/helmrelease.yaml`
+- `pi-fleet/helm/eldertree-app/`

--- a/runbook/issues/openclaw/OPENCLAW-009.md
+++ b/runbook/issues/openclaw/OPENCLAW-009.md
@@ -1,0 +1,52 @@
+---
+id: OPENCLAW-009
+title: OpenClaw OOM and Node Memory
+category: openclaw
+severity: high
+symptoms:
+  - Pod OOMKilled or CrashLoopBackOff
+  - FATAL ERROR Reached heap limit
+  - OpenClaw restart after heavy agent sessions
+---
+
+# OPENCLAW-009: OpenClaw OOM and Node Memory
+
+## Symptoms
+
+- OpenClaw pod **OOMKilled** or restart loop.
+- Logs: `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`.
+- Node under memory pressure on Raspberry Pi cluster.
+
+## Error Messages (Searchable)
+
+- `Reached heap limit`
+- `JavaScript heap out of memory`
+- `OOMKilled`
+- `Exit code 137`
+
+## Resolution
+
+Current Eldertree limits in `helmrelease.yaml`:
+
+- **`NODE_OPTIONS`**: `--max-old-space-size=2048`
+- **Pod memory**: request `1536Mi`, limit **`3Gi`**
+- Do not set Node heap close to pod limit (leave headroom for native memory).
+
+If OOM persists:
+
+1. Reduce concurrent sessions / restart pod after heavy use.
+2. Lower `contextTokens` or avoid huge tool outputs ([OPENCLAW-003](/runbook/issues/openclaw/OPENCLAW-003)).
+3. Check node memory: `kubectl top pods -n openclaw`.
+
+## Verification
+
+```bash
+kubectl get pod -n openclaw -l component=openclaw -o jsonpath='{.items[0].status.containerStatuses[0].lastState}'
+kubectl describe pod -n openclaw -l component=openclaw | grep -A5 Limits
+```
+
+Pod stays **Running** under normal Telegram load.
+
+## Related Files
+
+- `pi-fleet/clusters/eldertree/openclaw/helmrelease.yaml`


### PR DESCRIPTION
## Summary

- Add **OPENCLAW-002 through OPENCLAW-009** runbook entries documenting Eldertree production issues: token vs trusted-proxy WebSocket auth, context overflow / OpenRouter 402 / Groq TPM, Telegram 409 and egress, config EBUSY/PVC seeding, Groq tool schema errors, Gmail via Elder, Helm drift after accidental Deployment delete, and OOM/heap.
- Update **OPENCLAW-001** for current token-auth standard, in-pod `openclaw update` note, and cross-links.
- Extend runbook **index** and VitePress **sidebar** with all OpenClaw issue links.
- Fix **GitHub Pages deploy** workflow permissions (prior commit on this branch).

## Test plan

- [ ] VitePress build passes locally (`npm run docs:build` or project equivalent)
- [ ] After merge, verify https://docs.eldertree.xyz/runbook/issues/openclaw/ lists OPENCLAW-001–009
- [ ] GitHub Pages deploy workflow succeeds on `main`


Made with [Cursor](https://cursor.com)