### PR TITLE
docs: BIND9-001 runbook and Pi-hole archival

### DIFF
--- a/.vitepress/sidebar.ts
+++ b/.vitepress/sidebar.ts
@@ -9,6 +9,10 @@ export function sidebar() {
         text: "Project overview",
         link: "/project",
       },
+      {
+        text: "Cluster status",
+        link: "/cluster-status",
+      },
     ],
     "/runbook/": [
       {
@@ -28,7 +32,11 @@ export function sidebar() {
             link: "/runbook/issues/dns/DNS-001",
           },
           {
-            text: "PIHOLE-001: Pi-hole DNS",
+            text: "BIND9-001: LAN DNS",
+            link: "/runbook/issues/dns/BIND9-001",
+          },
+          {
+            text: "PIHOLE-001: Pi-hole (archived)",
             link: "/runbook/issues/dns/PIHOLE-001",
           },
         ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ After **1.0.0** release:
 
 ## [Unreleased]
 
+### Changed
+
+- **Cluster at a glance:** link to Eldertree Control Center (`control.eldertree.local`, LAN/Tailscale) in the ops links row.
+- **Home hero logo** — larger mark (280px) and vertical alignment with the headline on wide layouts.
+
 ### Added
 
 - **Cluster at a glance** on the home page — same widget as [pi-fleet-blog](https://blog.eldertree.xyz/) with indigo styling; live node status via Elder public API or [`public/cluster-status.json`](public/cluster-status.json).
@@ -28,6 +33,7 @@ After **1.0.0** release:
 
 ### Changed
 
+- **Docs:** [`cluster-status.md`](cluster-status.md) — home-page glance widget, sync script, links to Elder API and blog ops doc.
 - **Deploy workflow:** pre-build sync step for cluster-status (falls back to committed JSON in CI).
 - **`.npmrc`** — pin public npm registry (avoids corporate CodeArtifact E401 on personal machines).
 - **Home hero logo** — 512×512 icon crop (wordmark excluded), softer glow, `overflow: visible` so the mark is not clipped.

--- a/data/cluster.ts
+++ b/data/cluster.ts
@@ -58,6 +58,6 @@ export const cluster = {
   vips: [
     { label: "API", ip: "192.168.2.100", purpose: "kube-vip HA" },
     { label: "Ingress", ip: "192.168.2.200", purpose: "Traefik *.eldertree.local" },
-    { label: "DNS", ip: "192.168.2.201", purpose: "Pi-hole LB" },
+    { label: "DNS", ip: "192.168.2.201", purpose: "BIND9 LB" },
   ] satisfies ClusterVip[],
 } as const;

--- a/index.md
+++ b/index.md
@@ -7,8 +7,8 @@ hero:
   image:
     src: /logo.png
     alt: Eldertree cluster icon
-    width: 200
-    height: 200
+    width: 280
+    height: 280
   actions:
     - theme: brand
       text: Project overview
@@ -39,6 +39,7 @@ This documentation site serves as the incident runbook for the **eldertree** Kub
 
 ## Quick Links
 
+- [**Cluster status**](/cluster-status) - How the home-page glance widget gets live node badges
 - [**Project overview**](/project) - Cluster map, Grafana links, repos, and hardware
 - [**Runbook Overview**](/runbook/) - Browse all known issues by category
 - [**Agent Workflow**](/runbook/workflow) - Instructions for AI agents on how to use this runbook
@@ -61,7 +62,7 @@ Use the search bar (press `/` or `Ctrl+K`) to search for error messages or sympt
 
 | Category | Description |
 |----------|-------------|
-| DNS | CoreDNS, Pi-hole, and DNS resolution issues |
+| DNS | CoreDNS, BIND9, and DNS resolution issues |
 | Cloudflare | Tunnel, DNS, and external access issues |
 | Node | Node health, dual IP, and cluster membership |
 | Boot | Boot failures, NVMe, and system startup |

--- a/runbook/index.md
+++ b/runbook/index.md
@@ -16,7 +16,7 @@ This runbook contains documented solutions for known issues in the eldertree Kub
 | HTTP 530 from Cloudflare             | [CF-001](/runbook/issues/cloudflare/CF-001)                                            |
 | `dial udp 10.43.0.10:53 i/o timeout` | [CF-001](/runbook/issues/cloudflare/CF-001), [DNS-001](/runbook/issues/dns/DNS-001)    |
 | CoreDNS pod not running              | [DNS-001](/runbook/issues/dns/DNS-001)                                                 |
-| nslookup fails inside pods           | [DNS-001](/runbook/issues/dns/DNS-001), [PIHOLE-001](/runbook/issues/dns/PIHOLE-001)   |
+| nslookup fails inside pods           | [DNS-001](/runbook/issues/dns/DNS-001), [BIND9-001](/runbook/issues/dns/BIND9-001)   |
 | Node unreachable                     | [NODE-001](/runbook/issues/node/NODE-001), [NET-001](/runbook/issues/network/NET-001)  |
 | Node has multiple IPs                | [NODE-002](/runbook/issues/node/NODE-002), [NODE-003](/runbook/issues/node/NODE-003)   |
 | Boot failure / emergency mode        | [BOOT-001](/runbook/issues/boot/BOOT-001), [EMERG-001](/runbook/issues/boot/EMERG-001) |
@@ -47,7 +47,7 @@ This runbook contains documented solutions for known issues in the eldertree Kub
 #### DNS Issues
 
 - [DNS-001: CoreDNS Troubleshooting](/runbook/issues/dns/DNS-001)
-- [PIHOLE-001: Pi-hole DNS Issues](/runbook/issues/dns/PIHOLE-001)
+- [BIND9-001: BIND9 LAN DNS](/runbook/issues/dns/BIND9-001)
 
 #### Cloudflare Issues
 

--- a/runbook/issues/dns/BIND9-001.md
+++ b/runbook/issues/dns/BIND9-001.md
@@ -1,0 +1,69 @@
+---
+id: BIND9-001
+title: BIND9 LAN DNS Troubleshooting
+category: dns
+severity: high
+source: pi-fleet/clusters/eldertree/dns-services/bind/README.md
+symptoms:
+  - dig @192.168.2.201 returns NXDOMAIN or timeout
+  - external-dns CrashLoopBackOff
+  - verify-service-routing.sh fails LAN DNS check
+---
+
+# BIND9-001: BIND9 LAN DNS Troubleshooting
+
+> **Replaces PIHOLE-001** (Pi-hole decommissioned 2026-06). VIP unchanged: `192.168.2.201`.
+
+## Architecture
+
+- **Namespace:** `bind`
+- **HelmRelease:** `bind9`
+- **VIP:** `192.168.2.201` (kube-vip LoadBalancer, port 53)
+- **external-dns:** RFC2136 → `bind9.bind.svc.cluster.local:53`
+- **Zone:** `eldertree.local` → A records point to Traefik VIP `192.168.2.200`
+
+## Quick checks
+
+```bash
+export KUBECONFIG=~/.kube/config-eldertree
+
+# Cluster
+kubectl get pods,svc -n bind
+kubectl logs -n bind deployment/bind9 --tail=30
+kubectl get pods -n external-dns
+kubectl logs -n external-dns deployment/external-dns --tail=30
+
+# LAN (Mac)
+dig @192.168.2.201 grafana.eldertree.local +short   # expect 192.168.2.200
+dig @192.168.2.201 google.com +short                # recursion upstream
+
+# End-to-end
+cd pi-fleet && ./scripts/verify-service-routing.sh --host grafana.eldertree.local
+```
+
+## Mac diagnostic script
+
+```bash
+./scripts/diagnose-bind9-dns-mac.sh
+```
+
+## Common failures
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| VIP unreachable from Mac | kube-vip / Service LB | `kubectl get svc -n bind bind9`; check kube-vip logs |
+| NXDOMAIN for `*.eldertree.local` | external-dns down or TSIG mismatch | Check external-dns logs; `kubectl get externalsecret -n bind` |
+| external-dns CrashLoop | Wrong RFC2136 host/port | `helmrelease.yaml` → `bind9.bind.svc.cluster.local:53` |
+| Records stale after Ingress change | external-dns not reconciled | `flux reconcile helmrelease external-dns -n external-dns` |
+
+## Cutover (one-time)
+
+```bash
+./scripts/cutover-bind9-dns.sh
+```
+
+## Related
+
+- [DNS-001: CoreDNS](/runbook/issues/dns/DNS-001)
+- [PIHOLE-001 (archived)](/runbook/issues/dns/PIHOLE-001)
+- [pi-fleet#232](https://github.com/raolivei/pi-fleet/issues/232)

--- a/runbook/issues/dns/PIHOLE-001.md
+++ b/runbook/issues/dns/PIHOLE-001.md
@@ -10,6 +10,8 @@ symptoms:
 
 # PIHOLE-001: Pi-hole DNS Troubleshooting Guide
 
+> **ARCHIVED (2026-06):** Pi-hole removed from Eldertree. Use **[BIND9-001](/runbook/issues/dns/BIND9-001)** — VIP `192.168.2.201` unchanged.
+
 ## Error Messages (Searchable)
 
 _Add exact error messages from this document here for searchability_


### PR DESCRIPTION
## Summary
- Add `BIND9-001` LAN DNS troubleshooting runbook
- Archive `PIHOLE-001` with pointer to BIND9-001
- Update cluster manifest, sidebar, and runbook index

## Test plan
- [ ] VitePress build passes
- [ ] BIND9-001 renders at `/runbook/issues/dns/BIND9-001`


Made with [Cursor](https://cursor.com)